### PR TITLE
fix: Task State Inconsistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/src/hooks/__tests__/useTasks.test.tsx
+++ b/src/hooks/__tests__/useTasks.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { TaskProvider, useTaskContext } from '../../context/TaskContext';
+
+// Make async delays instant in tests
+jest.mock('../../utils/delay', () => ({
+  delayPatterns: {
+    short: () => Promise.resolve(),
+    medium: () => Promise.resolve(),
+    long: () => Promise.resolve(),
+    variable: () => Promise.resolve()
+  }
+}));
+
+// Remove debounce by setting auto-save delay to 0 in tests
+jest.mock('../../constants', () => ({
+  APP_CONFIG: { AUTO_SAVE_DELAY: 0 },
+  STORAGE_KEYS: { TASKS: 'tasks', USER_PREFERENCES: 'user-preferences', THEME: 'theme' }
+}));
+
+const wrapper: React.FC<{children: React.ReactNode}> = ({ children }) => (
+  <TaskProvider>{children}</TaskProvider>
+);
+
+const nextTick = () => new Promise(resolve => setTimeout(resolve, 0));
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  // no-op
+});
+
+test('Add → no refresh → task present', async () => {
+  const { result } = renderHook(() => useTaskContext(), { wrapper });
+  await act(async () => {
+    await result.current.loadTasks();
+  });
+  await act(async () => {
+    await result.current.addTask('New Task');
+  });
+  // allow effect to run
+  await act(async () => {
+    await nextTick();
+    await nextTick();
+  });
+  // debounce disabled via mock; no wait needed
+  expect(result.current.tasks.some(t => t.text === 'New Task')).toBe(true);
+});
+
+test('Add → remount/refresh → task persists', async () => {
+  const { result, unmount } = renderHook(() => useTaskContext(), { wrapper });
+  await act(async () => {
+    await result.current.loadTasks();
+  });
+  await act(async () => {
+    await result.current.addTask('Persisted Task');
+  });
+  await act(async () => {
+    await nextTick();
+    await nextTick();
+  });
+  // debounce disabled via mock
+
+  // simulate refresh by remounting provider
+  unmount();
+  const { result: result2 } = renderHook(() => useTaskContext(), { wrapper });
+  await act(async () => {
+    await result2.current.loadTasks();
+  });
+  expect(result2.current.tasks.some(t => t.text === 'Persisted Task')).toBe(true);
+});
+
+test('Toggle then Add quickly → storage matches latest after remount', async () => {
+  const { result, unmount } = renderHook(() => useTaskContext(), { wrapper });
+  await act(async () => {
+    await result.current.loadTasks();
+  });
+
+  const firstId = result.current.tasks[0].id;
+
+  await act(async () => {
+    const p1 = result.current.toggleTask(firstId);
+    const p2 = result.current.addTask('Fast Add');
+    await Promise.all([p1, p2]);
+  });
+  await act(async () => {
+    await nextTick();
+    await nextTick();
+  });
+
+  // simulate refresh
+  unmount();
+  const { result: result2 } = renderHook(() => useTaskContext(), { wrapper });
+  await act(async () => {
+    await result2.current.loadTasks();
+  });
+
+  const toggled = result2.current.tasks.find(t => t.id === firstId);
+  expect(toggled).toBeTruthy();
+  expect(result2.current.tasks.some(t => t.text === 'Fast Add')).toBe(true);
+});
+
+

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { APP_CONFIG } from '../constants';
 import { taskService } from '../services/taskService';
 import { Task, TaskContextType } from '../types';
 
@@ -6,6 +7,7 @@ export const useTasks = (): TaskContextType => {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+  const hydratedRef = useRef<boolean>(false);
 
   // Load tasks on mount
   useEffect(() => {
@@ -18,6 +20,7 @@ export const useTasks = (): TaskContextType => {
       setError(null);
       const loadedTasks = await taskService.loadTasks();
       setTasks(loadedTasks);
+      hydratedRef.current = true;
     } catch (err) {
       setError('Failed to load tasks');
       console.error('Error loading tasks:', err);
@@ -32,44 +35,48 @@ export const useTasks = (): TaskContextType => {
       setError(null);
       
       const newTask = await taskService.addTask(taskText);
-      const updatedTasks = [...tasks, newTask];
-      
-      setTasks(updatedTasks);
-      taskService.saveTasks(updatedTasks);
+      setTasks(prev => {
+        const updatedTasks = [...prev, newTask];
+        // Ensure immediate persistence for critical operations
+        if (hydratedRef.current) {
+          taskService.saveTasks(updatedTasks);
+        }
+        return updatedTasks;
+      });
     } catch (err) {
       setError('Failed to add task');
       console.error('Error adding task:', err);
     } finally {
       setIsLoading(false);
     }
-  }, [tasks]);
+  }, []);
 
   const toggleTask = useCallback(async (taskId: number) => {
     try {
       setIsLoading(true);
       setError(null);
       
-      const taskToUpdate = tasks.find(task => task.id === taskId);
-      if (!taskToUpdate) return;
-
-      const updates = await taskService.updateTask(taskId, {
-        ...taskToUpdate,
-        completed: !taskToUpdate.completed
+      setTasks(prev => {
+        const taskToUpdate = prev.find(task => task.id === taskId);
+        if (!taskToUpdate) return prev;
+        const updatedTasks = prev.map(task =>
+          task.id === taskId ? { ...task, completed: !task.completed } : task
+        );
+        // Ensure immediate persistence for critical operations
+        if (hydratedRef.current) {
+          taskService.saveTasks(updatedTasks);
+        }
+        return updatedTasks;
       });
-
-      const updatedTasks = tasks.map(task =>
-        task.id === taskId ? { ...task, ...updates } : task
-      );
-      
-      setTasks(updatedTasks);
-      taskService.saveTasks(updatedTasks);
+      // Update metadata asynchronously (e.g., updatedAt)
+      await taskService.updateTask(taskId, {});
     } catch (err) {
       setError('Failed to update task');
       console.error('Error updating task:', err);
     } finally {
       setIsLoading(false);
     }
-  }, [tasks]);
+  }, []);
 
   const deleteTask = useCallback(async (taskId: number) => {
     try {
@@ -77,17 +84,21 @@ export const useTasks = (): TaskContextType => {
       setError(null);
       
       await taskService.deleteTask(taskId);
-      const updatedTasks = tasks.filter(task => task.id !== taskId);
-      
-      setTasks(updatedTasks);
-      taskService.saveTasks(updatedTasks);
+      setTasks(prev => {
+        const updatedTasks = prev.filter(task => task.id !== taskId);
+        // Ensure immediate persistence for critical operations
+        if (hydratedRef.current) {
+          taskService.saveTasks(updatedTasks);
+        }
+        return updatedTasks;
+      });
     } catch (err) {
       setError('Failed to delete task');
       console.error('Error deleting task:', err);
     } finally {
       setIsLoading(false);
     }
-  }, [tasks]);
+  }, []);
 
   const refreshTasks = useCallback(async () => {
     try {
@@ -95,6 +106,7 @@ export const useTasks = (): TaskContextType => {
       setError(null);
       const refreshedTasks = await taskService.refreshTasks();
       setTasks(refreshedTasks);
+      hydratedRef.current = true;
     } catch (err) {
       setError('Failed to refresh tasks');
       console.error('Error refreshing tasks:', err);
@@ -102,6 +114,15 @@ export const useTasks = (): TaskContextType => {
       setIsLoading(false);
     }
   }, []);
+
+  // Persist tasks when state changes after hydration (debounced)
+  useEffect(() => {
+    if (!hydratedRef.current) return;
+    const handle = setTimeout(() => {
+      taskService.saveTasks(tasks);
+    }, APP_CONFIG.AUTO_SAVE_DELAY);
+    return () => clearTimeout(handle);
+  }, [tasks]);
 
   return {
     tasks,

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -29,7 +29,6 @@ export const taskService = {
       
       if (!tasks) {
         tasks = getDefaultTasks();
-        storageService.save(STORAGE_KEY, tasks);
       }
     }
     


### PR DESCRIPTION
### MR Summary: Fix task persistence race conditions after refresh
- Improved state updates and persistence to prevent lost/duplicated tasks after page refresh.
- Replaced stale-closure patterns with functional state updates in `useTasks`.
- Centralized persistence with a hydration-guarded effect; added debounce for write coalescing.
- Added immediate saves on critical operations (add/toggle/delete) to ensure durability.
- Stopped default writes during initial load to avoid write-before-read races.
- Added robust tests simulating remount/refresh; mocked delays and debounce to stabilize.
Key changes:
- `src/hooks/useTasks.ts`
  - Functional `setTasks`, `hydratedRef` to gate writes.
  - Debounced save effect using `APP_CONFIG.AUTO_SAVE_DELAY`.
  - Immediate `taskService.saveTasks(updatedTasks)` on add/toggle/delete when hydrated.
- `src/services/taskService.ts`
  - Removed `save` during `loadTasks` when defaults are used.
- `src/hooks/__tests__/useTasks.test.tsx`
  - Added tests for add without refresh, add with remount, toggle+add with remount.
  - Mocked delays and disabled debounce for deterministic execution.
Outcome:
- Eliminates out-of-order localStorage writes and stale overwrites.
- Tasks reliably persist across rapid actions and page reloads.
- All tests passing.