### PR TITLE
refactor: implement granular loading states for task operations

### DIFF
--- a/src/components/TaskApp.tsx
+++ b/src/components/TaskApp.tsx
@@ -5,7 +5,8 @@ import { Header, TaskForm, TaskList, LoadingIndicator } from './index';
 const TaskApp = () => {
   const {
     tasks,
-    isLoading,
+    isFetching,
+    isAdding,
     error,
     addTask,
     toggleTask,
@@ -32,22 +33,21 @@ const TaskApp = () => {
   return (
     <div className="app">
       <Header onRefresh={refreshTasks} />
-      
-      <TaskForm 
+
+      <TaskForm
         onAddTask={handleAddTask}
-        isLoading={isLoading}
+        isLoading={isAdding}
       />
-      
+
       <TaskList
         tasks={tasks}
         onToggleTask={toggleTask}
         onDeleteTask={deleteTask}
-        isLoading={isLoading}
       />
-      
-      <LoadingIndicator 
-        isLoading={isLoading}
-        message="Processing..."
+
+      <LoadingIndicator
+        isLoading={isFetching || isAdding || tasks.some(task => task.isToggling || task.isDeleting)}
+        message="Loading..."
       />
     </div>
   );

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -3,7 +3,7 @@ import { TaskItemProps } from '../types';
 
 const TaskItem: React.FC<TaskItemProps> = ({ task, onToggle, onDelete, isLoading }) => {
   const handleToggle = () => {
-    onToggle(task.id);
+    onToggle(task.id, !task.completed);
   };
 
   const handleDelete = () => {

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { TaskItemProps } from '../types';
 
-const TaskItem: React.FC<TaskItemProps> = ({ task, onToggle, onDelete, isLoading }) => {
+const TaskItem: React.FC<TaskItemProps> = ({ task, onToggle, onDelete }) => {
+  const isLoading = task.isToggling || task.isDeleting;
   const handleToggle = () => {
     onToggle(task.id, !task.completed);
   };

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import TaskItem from './TaskItem';
 import { TaskListProps } from '../types';
 
-const TaskList: React.FC<TaskListProps> = ({ tasks, onToggleTask, onDeleteTask, isLoading }) => {
+const TaskList: React.FC<TaskListProps> = ({ tasks, onToggleTask, onDeleteTask }) => {
   if (tasks.length === 0) {
     return (
       <div className="task-list">
@@ -21,7 +21,6 @@ const TaskList: React.FC<TaskListProps> = ({ tasks, onToggleTask, onDeleteTask, 
           task={task}
           onToggle={onToggleTask}
           onDelete={onDeleteTask}
-          isLoading={isLoading}
         />
       ))}
     </div>

--- a/src/components/__tests__/TaskItem.test.tsx
+++ b/src/components/__tests__/TaskItem.test.tsx
@@ -15,8 +15,7 @@ const mockTask: Task = {
 const mockProps = {
   task: mockTask,
   onToggle: jest.fn(),
-  onDelete: jest.fn(),
-  isLoading: false
+  onDelete: jest.fn()
 };
 
 describe('TaskItem', () => {
@@ -43,7 +42,7 @@ describe('TaskItem', () => {
     const checkbox = screen.getByRole('checkbox');
     fireEvent.click(checkbox);
     
-    expect(mockProps.onToggle).toHaveBeenCalledWith(1);
+    expect(mockProps.onToggle).toHaveBeenCalledWith(1, true);
   });
 
   it('calls onDelete when delete button is clicked', () => {
@@ -55,8 +54,20 @@ describe('TaskItem', () => {
     expect(mockProps.onDelete).toHaveBeenCalledWith(1);
   });
 
-  it('disables controls when loading', () => {
-    render(<TaskItem {...mockProps} isLoading={true} />);
+  it('disables controls when task is toggling', () => {
+    const togglingTask = { ...mockTask, isToggling: true };
+    render(<TaskItem {...mockProps} task={togglingTask} />);
+    
+    const checkbox = screen.getByRole('checkbox');
+    const deleteButton = screen.getByRole('button', { name: /delete/i });
+    
+    expect(checkbox).toBeDisabled();
+    expect(deleteButton).toBeDisabled();
+  });
+
+  it('disables controls when task is deleting', () => {
+    const deletingTask = { ...mockTask, isDeleting: true };
+    render(<TaskItem {...mockProps} task={deletingTask} />);
     
     const checkbox = screen.getByRole('checkbox');
     const deleteButton = screen.getByRole('button', { name: /delete/i });

--- a/src/hooks/__tests__/useTasks.test.ts
+++ b/src/hooks/__tests__/useTasks.test.ts
@@ -39,7 +39,7 @@ describe('useTasks race conditions', () => {
     const { result } = renderHook(() => useTasks());
 
     await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isFetching).toBe(false);
     });
 
     await act(async () => {
@@ -73,7 +73,7 @@ describe('useTasks race conditions', () => {
     const { result } = renderHook(() => useTasks());
 
     await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isFetching).toBe(false);
     });
 
     expect(result.current.tasks).toHaveLength(0);

--- a/src/hooks/__tests__/useTasks.test.ts
+++ b/src/hooks/__tests__/useTasks.test.ts
@@ -1,0 +1,432 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useTasks } from '../useTasks';
+import { taskService } from '../../services/taskService';
+import { storageService } from '../../utils/storage';
+import { Task } from '../../types';
+
+jest.mock('../../services/taskService');
+jest.mock('../../utils/storage');
+
+describe('useTasks race conditions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (storageService.load as jest.Mock).mockReturnValue([]);
+    (storageService.save as jest.Mock).mockReturnValue(true);
+
+    (taskService.loadTasks as jest.Mock).mockResolvedValue([]);
+    (taskService.saveTasks as jest.Mock).mockResolvedValue(true);
+  });
+
+  it('should add a new task', async () => {
+    let addTaskCallCount = 0;
+
+    (taskService.addTask as jest.Mock).mockImplementation(async (taskText: string) => {
+      addTaskCallCount++;
+      const taskId = 2000 + addTaskCallCount;
+
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      return {
+        id: taskId,
+        text: taskText,
+        completed: false,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+    });
+
+    const { result } = renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.addTask('Task 1');
+    });
+
+    expect(result.current.tasks).toHaveLength(1);
+    expect(result.current.tasks[0].text).toContain('Task 1');
+  });
+
+  it('should add two tasks simultaneously', async () => {
+    let addTaskCallCount = 0;
+
+    (taskService.addTask as jest.Mock).mockImplementation(async (taskText: string) => {
+      addTaskCallCount++;
+      const taskId = 1000 + addTaskCallCount;
+
+      await new Promise(resolve => setTimeout(resolve, 100 + Math.random() * 100));
+
+      const newTask: Task = {
+        id: taskId,
+        text: taskText,
+        completed: false,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+
+      return newTask;
+    });
+
+    const { result } = renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.tasks).toHaveLength(0);
+
+    await act(async () => {
+      await Promise.all([
+        result.current.addTask('Task 1'),
+        result.current.addTask('Task 2'),
+      ]);
+    });
+
+    expect(result.current.tasks).toHaveLength(2);
+    expect(result.current.tasks.map(t => t.text)).toContain('Task 1');
+    expect(result.current.tasks.map(t => t.text)).toContain('Task 2');
+  });
+
+  it('should complete/incomplete a task', async () => {
+    const initialTasks: Task[] = [
+      { id: 1, text: 'Task to toggle', completed: false, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+      { id: 2, text: 'Another task', completed: false, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+    ];
+
+    (taskService.loadTasks as jest.Mock).mockImplementation(async () => initialTasks);
+
+    (taskService.updateTask as jest.Mock).mockImplementation(async (taskId: number, updates: Partial<Task>) => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+      return {
+        ...updates,
+        updatedAt: new Date().toISOString(),
+      };
+    });
+
+    const { result } = renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(result.current.tasks).toHaveLength(2);
+    });
+
+    expect(result.current.tasks[0].completed).toBe(false);
+
+    await act(async () => {
+      await result.current.toggleTask(1, true);
+    });
+
+    expect(result.current.tasks[0].completed).toBe(true);
+    expect(result.current.tasks[1].completed).toBe(false);
+
+    await act(async () => {
+      await result.current.toggleTask(1, false);
+    });
+
+    expect(result.current.tasks[0].completed).toBe(false);
+    expect(result.current.tasks[1].completed).toBe(false);
+  });
+
+  it('should complete/incomplete two tasks simultaneously', async () => {
+    const initialTasks: Task[] = [
+      { id: 1, text: 'First task to toggle', completed: false, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+      { id: 2, text: 'Second task to toggle', completed: false, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+    ];
+
+    (taskService.loadTasks as jest.Mock).mockImplementation(async () => initialTasks);
+
+    (taskService.updateTask as jest.Mock).mockImplementation(async (taskId: number, updates: Partial<Task>) => {
+      await new Promise(resolve => setTimeout(resolve, 50 + Math.random() * 100));
+      return {
+        ...updates,
+        updatedAt: new Date().toISOString(),
+      };
+    });
+
+    const { result } = renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(result.current.tasks).toHaveLength(2);
+    });
+
+    expect(result.current.tasks[0].completed).toBe(false);
+    expect(result.current.tasks[1].completed).toBe(false);
+
+    await act(async () => {
+      await Promise.all([
+        result.current.toggleTask(1, true),
+        result.current.toggleTask(2, true),
+      ]);
+    });
+
+    expect(result.current.tasks[0].completed).toBe(true);
+    expect(result.current.tasks[1].completed).toBe(true);
+  });
+
+  it('should delete a task', async () => {
+    const initialTasks: Task[] = [
+      { id: 1, text: 'Task to delete', completed: false, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+      { id: 2, text: 'Task to keep', completed: false, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+      { id: 3, text: 'Another task to keep', completed: false, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+    ];
+
+    (taskService.loadTasks as jest.Mock).mockImplementation(async () => initialTasks);
+
+    (taskService.deleteTask as jest.Mock).mockImplementation(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+      return 1;
+    });
+
+    const { result } = renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(result.current.tasks).toHaveLength(3);
+    });
+
+    await act(async () => {
+      await result.current.deleteTask(1);
+    });
+
+    expect(result.current.tasks).toHaveLength(2);
+    expect(result.current.tasks.map(t => t.id)).toContain(2);
+    expect(result.current.tasks.map(t => t.id)).toContain(3);
+    expect(result.current.tasks.map(t => t.id)).not.toContain(1);
+  });
+
+  it('should delete two tasks simultaneously', async () => {
+    const initialTasks: Task[] = [
+      { id: 1, text: 'First task to delete', completed: false, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+      { id: 2, text: 'Second task to delete', completed: false, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+      { id: 3, text: 'Task to keep', completed: false, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+    ];
+
+    (taskService.loadTasks as jest.Mock).mockImplementation(async () => initialTasks);
+
+    (taskService.deleteTask as jest.Mock).mockImplementation(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50 + Math.random() * 100));
+      return 1;
+    });
+
+    const { result } = renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(result.current.tasks).toHaveLength(3);
+    });
+
+    await act(async () => {
+      await Promise.all([
+        result.current.deleteTask(1),
+        result.current.deleteTask(2),
+      ]);
+    });
+
+    expect(result.current.tasks).toHaveLength(1);
+    expect(result.current.tasks[0].id).toBe(3);
+  });
+
+  it('should handle simultaneous add and complete operations', async () => {
+    const initialTasks: Task[] = [
+      { id: 1, text: 'Existing task', completed: false, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+    ];
+
+    let addTaskCallCount = 0;
+
+    (taskService.loadTasks as jest.Mock).mockResolvedValue(initialTasks);
+
+    (taskService.addTask as jest.Mock).mockImplementation(async (taskText: string) => {
+      addTaskCallCount++;
+      const taskId = 2000 + addTaskCallCount;
+
+      await new Promise(resolve => setTimeout(resolve, 100 + Math.random() * 100));
+
+      return {
+        id: taskId,
+        text: taskText,
+        completed: false,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+    });
+
+    (taskService.updateTask as jest.Mock).mockImplementation(async (taskId: number, updates: Partial<Task>) => {
+      await new Promise(resolve => setTimeout(resolve, 100 + Math.random() * 100));
+      return {
+        ...updates,
+        updatedAt: new Date().toISOString(),
+      };
+    });
+
+    const { result } = renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(result.current.tasks).toHaveLength(1);
+    });
+
+    await act(async () => {
+      await Promise.all([
+        result.current.addTask('New task'),
+        result.current.toggleTask(1, true),
+      ]);
+    });
+
+    expect(result.current.tasks).toHaveLength(2);
+
+    const existingTask = result.current.tasks.find(t => t.id === 1);
+    expect(existingTask).toBeDefined();
+    expect(existingTask?.completed).toBe(true);
+
+    const newTask = result.current.tasks.find(t => t.text === 'New task');
+    expect(newTask).toBeDefined();
+    expect(newTask?.completed).toBe(false);
+  });
+
+  it('should handle simultaneous delete and add operations', async () => {
+    const initialTasks: Task[] = [
+      { id: 1, text: 'Task 1', completed: false, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+      { id: 2, text: 'Task 2', completed: false, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+    ];
+
+    let addTaskCallCount = 0;
+
+    (taskService.loadTasks as jest.Mock).mockResolvedValue(initialTasks);
+
+    (taskService.deleteTask as jest.Mock).mockImplementation(async () => {
+      await new Promise(resolve => setTimeout(resolve, 100 + Math.random() * 100));
+      return 1;
+    });
+
+    (taskService.addTask as jest.Mock).mockImplementation(async (taskText: string) => {
+      addTaskCallCount++;
+      const taskId = 3000 + addTaskCallCount;
+
+      await new Promise(resolve => setTimeout(resolve, 100 + Math.random() * 100));
+
+      return {
+        id: taskId,
+        text: taskText,
+        completed: false,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+    });
+
+    const { result } = renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(result.current.tasks).toHaveLength(2);
+    });
+
+    await act(async () => {
+      await Promise.all([
+        result.current.deleteTask(1),
+        result.current.addTask('Replacement task'),
+      ]);
+    });
+
+    expect(result.current.tasks).toHaveLength(2);
+
+    expect(result.current.tasks.map(t => t.id)).toContain(2);
+
+    expect(result.current.tasks.map(t => t.text)).toContain('Replacement task');
+
+    expect(result.current.tasks.map(t => t.id)).not.toContain(1);
+  });
+
+  it('should handle simultaneous delete and complete operations', async () => {
+    const initialTasks: Task[] = [
+      { id: 1, text: 'Task to delete', completed: false, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+      { id: 2, text: 'Task to complete', completed: false, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+    ];
+
+    (taskService.loadTasks as jest.Mock).mockImplementation(async () => initialTasks);
+
+    (taskService.deleteTask as jest.Mock).mockImplementation(async () => {
+      await new Promise(resolve => setTimeout(resolve, 100 + Math.random() * 100));
+      return 1;
+    });
+
+    (taskService.updateTask as jest.Mock).mockImplementation(async (taskId: number, updates: Partial<Task>) => {
+      await new Promise(resolve => setTimeout(resolve, 100 + Math.random() * 100));
+      return {
+        ...updates,
+        updatedAt: new Date().toISOString(),
+      };
+    });
+
+    const { result } = renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(result.current.tasks).toHaveLength(2);
+    });
+
+    await act(async () => {
+      await Promise.all([
+        result.current.deleteTask(1),
+        result.current.toggleTask(2, true),
+      ]);
+    });
+
+    expect(result.current.tasks).toHaveLength(1);
+
+    const remainingTask = result.current.tasks[0];
+    expect(remainingTask.id).toBe(2);
+    expect(remainingTask.completed).toBe(true);
+    expect(result.current.tasks.map(t => t.id)).not.toContain(1);
+  });
+
+  it('should handle simultaneous add and refresh operations', async () => {
+    const initialTasks: Task[] = [
+      { id: 1, text: 'Existing', completed: false, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+    ];
+
+    const refreshedTasks: Task[] = [
+      { id: 1, text: 'Existing', completed: false, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+      { id: 999, text: 'Server task', completed: false, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+    ];
+
+    let loadCallCount = 0;
+    (taskService.loadTasks as jest.Mock).mockImplementation(async () => {
+      loadCallCount++;
+      if (loadCallCount === 1) {
+        return initialTasks;
+      }
+      return refreshedTasks;
+    });
+
+    (taskService.addTask as jest.Mock).mockImplementation(async (taskText: string) => {
+      await new Promise(resolve => setTimeout(resolve, 100 + Math.random() * 100));
+      return {
+        id: 5000,
+        text: taskText,
+        completed: false,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+    });
+
+    (taskService.refreshTasks as jest.Mock).mockImplementation(async () => refreshedTasks);
+
+    const { result } = renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(result.current.tasks).toHaveLength(1);
+    });
+
+    await act(async () => {
+      await Promise.all([
+        result.current.addTask('New task'),
+        result.current.refreshTasks(),
+      ]);
+    });
+
+    expect(result.current.tasks.length).toBeGreaterThanOrEqual(2);
+    expect(result.current.tasks.length).toBeLessThanOrEqual(3);
+
+    expect(result.current.tasks.map(t => t.id)).toContain(1);
+
+    const hasNewTask = result.current.tasks.some(t => t.id === 5000 || t.id === 999);
+    expect(hasNewTask).toBe(true);
+  });
+});

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -5,7 +5,8 @@ import { Task, TaskContextType } from '../types';
 export const useTasks = (): TaskContextType => {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [isFetching, setIsFetching] = useState<boolean>(true);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isAdding, setIsAdding] = useState<boolean>(false);
+  const [isRefreshing, setIsRefreshing] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
 
   // Updates storage
@@ -15,6 +16,7 @@ export const useTasks = (): TaskContextType => {
 
   const loadTasks = useCallback(async () => {
     try {
+      setIsFetching(true);
       setError(null);
       const loadedTasks = await taskService.loadTasks();
       setTasks(loadedTasks);
@@ -33,7 +35,7 @@ export const useTasks = (): TaskContextType => {
 
   const addTask = useCallback(async (taskText: string) => {
     try {
-      setIsLoading(true);
+      setIsAdding(true);
       setError(null);
       const newTask = await taskService.addTask(taskText);
       setTasks(tasks => [...tasks, newTask]);
@@ -41,43 +43,59 @@ export const useTasks = (): TaskContextType => {
       setError('Failed to add task');
       console.error('Error adding task:', err);
     } finally {
-      setIsLoading(false);
+      setIsAdding(false);
     }
   }, []);
 
   const toggleTask = useCallback(async (taskId: number, completed: boolean) => {
     try {
-      setIsLoading(true);
+      // Set isToggling to true for this specific task
+      setTasks(prev => prev.map(task => 
+        task.id === taskId ? { ...task, isToggling: true } : task
+      ));
       setError(null);
+      
       const updates = await taskService.updateTask(taskId, { completed });
-      setTasks(tasks => tasks.map(task =>
-        task.id === taskId ? { ...task, ...updates } : task
+      
+      // Update the task and set isToggling to false
+      setTasks(prev => prev.map(task => 
+        task.id === taskId ? { ...task, ...updates, isToggling: false } : task
       ));
     } catch (err) {
       setError('Failed to update task');
       console.error('Error updating task:', err);
-    } finally {
-      setIsLoading(false);
+      // Reset isToggling on error
+      setTasks(prev => prev.map(task => 
+        task.id === taskId ? { ...task, isToggling: false } : task
+      ));
     }
   }, []);
 
   const deleteTask = useCallback(async (taskId: number) => {
     try {
-      setIsLoading(true);
+      // Set isDeleting to true for this specific task
+      setTasks(prev => prev.map(task => 
+        task.id === taskId ? { ...task, isDeleting: true } : task
+      ));
       setError(null);
+      
       await taskService.deleteTask(taskId);
-      setTasks(tasks => tasks.filter(task => task.id !== taskId));
+      
+      // Remove the task from state after successful deletion
+      setTasks(prev => prev.filter(task => task.id !== taskId));
     } catch (err) {
       setError('Failed to delete task');
       console.error('Error deleting task:', err);
-    } finally {
-      setIsLoading(false);
+      // Reset isDeleting on error
+      setTasks(prev => prev.map(task => 
+        task.id === taskId ? { ...task, isDeleting: false } : task
+      ));
     }
   }, []);
 
   const refreshTasks = useCallback(async () => {
     try {
-      setIsLoading(true);
+      setIsRefreshing(true);
       setError(null);
       const refreshedTasks = await taskService.refreshTasks();
       setTasks(refreshedTasks);
@@ -85,13 +103,15 @@ export const useTasks = (): TaskContextType => {
       setError('Failed to refresh tasks');
       console.error('Error refreshing tasks:', err);
     } finally {
-      setIsLoading(false);
+      setIsRefreshing(false);
     }
   }, []);
 
   return {
     tasks,
-    isLoading: isFetching || isLoading,
+    isFetching,
+    isAdding,
+    isRefreshing,
     error,
     addTask,
     toggleTask,

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -4,17 +4,17 @@ import { Task, TaskContextType } from '../types';
 
 export const useTasks = (): TaskContextType => {
   const [tasks, setTasks] = useState<Task[]>([]);
+  const [isFetching, setIsFetching] = useState<boolean>(true);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Load tasks on mount
+  // Updates storage
   useEffect(() => {
-    loadTasks();
-  }, []);
+    if (!isFetching) taskService.saveTasks(tasks)
+  }, [tasks, isFetching]);
 
   const loadTasks = useCallback(async () => {
     try {
-      setIsLoading(true);
       setError(null);
       const loadedTasks = await taskService.loadTasks();
       setTasks(loadedTasks);
@@ -22,72 +22,58 @@ export const useTasks = (): TaskContextType => {
       setError('Failed to load tasks');
       console.error('Error loading tasks:', err);
     } finally {
-      setIsLoading(false);
+      setIsFetching(false);
     }
   }, []);
+
+  // Load tasks on mount
+  useEffect(() => {
+    loadTasks();
+  }, [loadTasks]);
 
   const addTask = useCallback(async (taskText: string) => {
     try {
       setIsLoading(true);
       setError(null);
-      
       const newTask = await taskService.addTask(taskText);
-      const updatedTasks = [...tasks, newTask];
-      
-      setTasks(updatedTasks);
-      taskService.saveTasks(updatedTasks);
+      setTasks(tasks => [...tasks, newTask]);
     } catch (err) {
       setError('Failed to add task');
       console.error('Error adding task:', err);
     } finally {
       setIsLoading(false);
     }
-  }, [tasks]);
+  }, []);
 
-  const toggleTask = useCallback(async (taskId: number) => {
+  const toggleTask = useCallback(async (taskId: number, completed: boolean) => {
     try {
       setIsLoading(true);
       setError(null);
-      
-      const taskToUpdate = tasks.find(task => task.id === taskId);
-      if (!taskToUpdate) return;
-
-      const updates = await taskService.updateTask(taskId, {
-        ...taskToUpdate,
-        completed: !taskToUpdate.completed
-      });
-
-      const updatedTasks = tasks.map(task =>
+      const updates = await taskService.updateTask(taskId, { completed });
+      setTasks(tasks => tasks.map(task =>
         task.id === taskId ? { ...task, ...updates } : task
-      );
-      
-      setTasks(updatedTasks);
-      taskService.saveTasks(updatedTasks);
+      ));
     } catch (err) {
       setError('Failed to update task');
       console.error('Error updating task:', err);
     } finally {
       setIsLoading(false);
     }
-  }, [tasks]);
+  }, []);
 
   const deleteTask = useCallback(async (taskId: number) => {
     try {
       setIsLoading(true);
       setError(null);
-      
       await taskService.deleteTask(taskId);
-      const updatedTasks = tasks.filter(task => task.id !== taskId);
-      
-      setTasks(updatedTasks);
-      taskService.saveTasks(updatedTasks);
+      setTasks(tasks => tasks.filter(task => task.id !== taskId));
     } catch (err) {
       setError('Failed to delete task');
       console.error('Error deleting task:', err);
     } finally {
       setIsLoading(false);
     }
-  }, [tasks]);
+  }, []);
 
   const refreshTasks = useCallback(async () => {
     try {
@@ -105,7 +91,7 @@ export const useTasks = (): TaskContextType => {
 
   return {
     tasks,
-    isLoading,
+    isLoading: isFetching || isLoading,
     error,
     addTask,
     toggleTask,

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -8,13 +8,16 @@ import { STORAGE_KEYS } from '../constants';
 const STORAGE_KEY = STORAGE_KEYS.TASKS;
 
 // Default tasks for initial app state
-const getDefaultTasks = (): Task[] => [
-  { id: 1, text: 'Review marketing campaign proposal', completed: false },
-  { id: 2, text: 'Schedule team meeting for next week', completed: false },
-  { id: 3, text: 'Update project timeline document', completed: true },
-  { id: 4, text: 'Send follow-up email to client', completed: false },
-  { id: 5, text: 'Prepare presentation slides', completed: false }
-];
+const getDefaultTasks = (): Task[] => {
+  const now = new Date().toISOString();
+  return [
+    { id: 1, text: 'Review marketing campaign proposal', completed: false, createdAt: now, updatedAt: now },
+    { id: 2, text: 'Schedule team meeting for next week', completed: false, createdAt: now, updatedAt: now },
+    { id: 3, text: 'Update project timeline document', completed: true, createdAt: now, updatedAt: now },
+    { id: 4, text: 'Send follow-up email to client', completed: false, createdAt: now, updatedAt: now },
+    { id: 5, text: 'Prepare presentation slides', completed: false, createdAt: now, updatedAt: now }
+  ];
+};
 
 export const taskService = {
   // Load tasks from storage

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,7 +11,7 @@ export interface TaskContextType {
   isLoading: boolean;
   error: string | null;
   addTask: (taskText: string) => Promise<void>;
-  toggleTask: (taskId: number) => Promise<void>;
+  toggleTask: (taskId: number, completed: boolean) => Promise<void>;
   deleteTask: (taskId: number) => Promise<void>;
   refreshTasks: () => Promise<void>;
   loadTasks: () => Promise<void>;
@@ -24,14 +24,14 @@ export interface TaskFormProps {
 
 export interface TaskItemProps {
   task: Task;
-  onToggle: (taskId: number) => Promise<void>;
+  onToggle: (taskId: number, completed: boolean) => Promise<void>;
   onDelete: (taskId: number) => Promise<void>;
   isLoading: boolean;
 }
 
 export interface TaskListProps {
   tasks: Task[];
-  onToggleTask: (taskId: number) => Promise<void>;
+  onToggleTask: (taskId: number, completed: boolean) => Promise<void>;
   onDeleteTask: (taskId: number) => Promise<void>;
   isLoading: boolean;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,13 +2,17 @@ export interface Task {
   id: number;
   text: string;
   completed: boolean;
-  createdAt?: string;
-  updatedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+  isToggling?: boolean;  // Track if this task is being toggled
+  isDeleting?: boolean;  // Track if this task is being deleted
 }
 
 export interface TaskContextType {
   tasks: Task[];
-  isLoading: boolean;
+  isFetching: boolean;
+  isAdding: boolean;
+  isRefreshing: boolean;
   error: string | null;
   addTask: (taskText: string) => Promise<void>;
   toggleTask: (taskId: number, completed: boolean) => Promise<void>;
@@ -26,14 +30,12 @@ export interface TaskItemProps {
   task: Task;
   onToggle: (taskId: number, completed: boolean) => Promise<void>;
   onDelete: (taskId: number) => Promise<void>;
-  isLoading: boolean;
 }
 
 export interface TaskListProps {
   tasks: Task[];
   onToggleTask: (taskId: number, completed: boolean) => Promise<void>;
   onDeleteTask: (taskId: number) => Promise<void>;
-  isLoading: boolean;
 }
 
 export interface HeaderProps {


### PR DESCRIPTION
This PR improves UX by replacing global loading state with granular per-operation states.

## Changes
- Extend Task type with isToggling and isDeleting flags
- Replace monolithic isLoading with 3 separate states:
  - isFetching: initial load from storage
  - isAdding: add task operation  
  - isRefreshing: refresh operation
- Track per-task loading states for toggle and delete
- Enable concurrent operations on different tasks
- Update all components to use new loading patterns

## Benefits
- Toggle task 1 while deleting task 2
- Add new task while refreshing list
- Specific loading indicators per task
- No unnecessary UI blocking